### PR TITLE
fix: remove tabindex from tt-list

### DIFF
--- a/src/typeahead-standalone.ts
+++ b/src/typeahead-standalone.ts
@@ -130,7 +130,6 @@ const typeahead = <T extends Dictionary>(config: typeaheadConfig<T>): typeaheadR
   hint && injectHintEl(inputHint);
 
   listContainer.classList.add(classNames.list, classNames.hide);
-  listContainer.tabIndex = 0;
   listContainer.setAttribute('aria-label', 'menu-options');
   listContainer.setAttribute('role', 'listbox');
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [X] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [X] It's submitted to the `develop` branch (or `v[X]` branch)
- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: [#xxx]`, where "xxx" is the issue number)
- [X] Any necessary documentation has been added or updated [in the docs](https://github.com/digitalfortress-tech/localstorage-slim#readme) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.


**Other information:**
This pull request removes the tabindex from the '.tt-list' element, as the Tab key functionality is unnecessary in this context. Previously, when no suggestions were present and the 'noResult' template was displayed, pressing the Tab key would trigger a keydown event and focus on the list, rather than moving to the next input field. This change ensures more intuitive navigation by preventing the list from being focused in such cases.