### PR TITLE
Fix uncaught JSON.parse exception in handleResponse

### DIFF
--- a/src/fetchWrapper/fetchWrapper.ts
+++ b/src/fetchWrapper/fetchWrapper.ts
@@ -14,7 +14,12 @@ const get = async function (url: RequestInfo | URL, requestOptions?: RequestInit
 // helper function
 const handleResponse = async function (response: Response) {
   const text = await response.text();
-  const data = text && JSON.parse(text);
+  let data: unknown;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch (error) {
+    data = null;
+  }
   if (!response.ok) {
     return Promise.reject((data && data.message) || response.statusText);
   }


### PR DESCRIPTION
## Problem

The `handleResponse` function calls `JSON.parse(text)` without a try-catch block. If the server returns malformed JSON (e.g., HTML error page, plain text), `JSON.parse` throws a `SyntaxError` that is not caught, causing the promise to reject with an unhandled exception.

## Solution

Wrap the `JSON.parse` call in a try-catch block to gracefully handle malformed JSON responses. When parsing fails, `data` is set to `null`, allowing the existing error handling logic to continue functioning correctly.

## Changes

- Modified `handleResponse` in `src/fetchWrapper/fetchWrapper.ts`
- Added try-catch around `JSON.parse(text)` call
- On parse error, `data` is set to `null` instead of throwing an uncaught exception

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.